### PR TITLE
Hardcode all packages under dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,30 +12,6 @@ updates:
       timezone: UTC
       time: "07:00"
   - package-ecosystem: "npm"
-    directory: "svelte"
-    schedule:
-      internal: "monthly"
-      timezone: UTC
-      time: "07:00"
-  - package-ecosystem: "npm"
-    directory: "react-native"
-    schedule:
-      internal: "monthly"
-      timezone: UTC
-      time: "07:00"
-  - package-ecosystem: "npm"
-    directory: "plain"
-    schedule:
-      internal: "monthly"
-      timezone: UTC
-      time: "07:00"
-  - package-ecosystem: "npm"
-    directory: "vue"
-    schedule:
-      internal: "monthly"
-      timezone: UTC
-      time: "07:00"
-  - package-ecosystem: "npm"
     directory: "angular"
     schedule:
       internal: "monthly"
@@ -48,37 +24,13 @@ updates:
       timezone: UTC
       time: "07:00"
   - package-ecosystem: "npm"
-    directory: "remix"
+    directory: "plain"
     schedule:
       internal: "monthly"
       timezone: UTC
       time: "07:00"
   - package-ecosystem: "npm"
-    directory: "react/yarn3"
-    schedule:
-      internal: "monthly"
-      timezone: UTC
-      time: "07:00"
-  - package-ecosystem: "npm"
-    directory: "react/parcel"
-    schedule:
-      internal: "monthly"
-      timezone: UTC
-      time: "07:00"
-  - package-ecosystem: "npm"
-    directory: "react/webpack"
-    schedule:
-      internal: "monthly"
-      timezone: UTC
-      time: "07:00"
-  - package-ecosystem: "npm"
-    directory: "react/vite"
-    schedule:
-      internal: "monthly"
-      timezone: UTC
-      time: "07:00"
-  - package-ecosystem: "npm"
-    directory: "react/rollup"
+    directory: "react-native"
     schedule:
       internal: "monthly"
       timezone: UTC
@@ -96,7 +48,55 @@ updates:
       timezone: UTC
       time: "07:00"
   - package-ecosystem: "npm"
+    directory: "react/parcel"
+    schedule:
+      internal: "monthly"
+      timezone: UTC
+      time: "07:00"
+  - package-ecosystem: "npm"
+    directory: "react/rollup"
+    schedule:
+      internal: "monthly"
+      timezone: UTC
+      time: "07:00"
+  - package-ecosystem: "npm"
+    directory: "react/vite"
+    schedule:
+      internal: "monthly"
+      timezone: UTC
+      time: "07:00"
+  - package-ecosystem: "npm"
+    directory: "react/webpack"
+    schedule:
+      internal: "monthly"
+      timezone: UTC
+      time: "07:00"
+  - package-ecosystem: "npm"
     directory: "react/yarn3-unplugged"
+    schedule:
+      internal: "monthly"
+      timezone: UTC
+      time: "07:00"
+  - package-ecosystem: "npm"
+    directory: "react/yarn3"
+    schedule:
+      internal: "monthly"
+      timezone: UTC
+      time: "07:00"
+  - package-ecosystem: "npm"
+    directory: "remix"
+    schedule:
+      internal: "monthly"
+      timezone: UTC
+      time: "07:00"
+  - package-ecosystem: "npm"
+    directory: "svelte"
+    schedule:
+      internal: "monthly"
+      timezone: UTC
+      time: "07:00"
+  - package-ecosystem: "npm"
+    directory: "vue"
     schedule:
       internal: "monthly"
       timezone: UTC

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,9 +12,93 @@ updates:
       timezone: UTC
       time: "07:00"
   - package-ecosystem: "npm"
-    directory: "/"
+    directory: "svelte"
     schedule:
-      interval: "monthly"
+      internal: "monthly"
       timezone: UTC
       time: "07:00"
-    open-pull-requests-limit: 50
+  - package-ecosystem: "npm"
+    directory: "react-native"
+    schedule:
+      internal: "monthly"
+      timezone: UTC
+      time: "07:00"
+  - package-ecosystem: "npm"
+    directory: "plain"
+    schedule:
+      internal: "monthly"
+      timezone: UTC
+      time: "07:00"
+  - package-ecosystem: "npm"
+    directory: "vue"
+    schedule:
+      internal: "monthly"
+      timezone: UTC
+      time: "07:00"
+  - package-ecosystem: "npm"
+    directory: "angular"
+    schedule:
+      internal: "monthly"
+      timezone: UTC
+      time: "07:00"
+  - package-ecosystem: "npm"
+    directory: "nextjs"
+    schedule:
+      internal: "monthly"
+      timezone: UTC
+      time: "07:00"
+  - package-ecosystem: "npm"
+    directory: "remix"
+    schedule:
+      internal: "monthly"
+      timezone: UTC
+      time: "07:00"
+  - package-ecosystem: "npm"
+    directory: "react/yarn3"
+    schedule:
+      internal: "monthly"
+      timezone: UTC
+      time: "07:00"
+  - package-ecosystem: "npm"
+    directory: "react/parcel"
+    schedule:
+      internal: "monthly"
+      timezone: UTC
+      time: "07:00"
+  - package-ecosystem: "npm"
+    directory: "react/webpack"
+    schedule:
+      internal: "monthly"
+      timezone: UTC
+      time: "07:00"
+  - package-ecosystem: "npm"
+    directory: "react/vite"
+    schedule:
+      internal: "monthly"
+      timezone: UTC
+      time: "07:00"
+  - package-ecosystem: "npm"
+    directory: "react/rollup"
+    schedule:
+      internal: "monthly"
+      timezone: UTC
+      time: "07:00"
+  - package-ecosystem: "npm"
+    directory: "react/cra"
+    schedule:
+      internal: "monthly"
+      timezone: UTC
+      time: "07:00"
+  - package-ecosystem: "npm"
+    directory: "react/esbuild"
+    schedule:
+      internal: "monthly"
+      timezone: UTC
+      time: "07:00"
+  - package-ecosystem: "npm"
+    directory: "react/yarn3-unplugged"
+    schedule:
+      internal: "monthly"
+      timezone: UTC
+      time: "07:00"
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,91 +14,90 @@ updates:
   - package-ecosystem: "npm"
     directory: "angular"
     schedule:
-      internal: "monthly"
+      interval: "monthly"
       timezone: UTC
       time: "07:00"
   - package-ecosystem: "npm"
     directory: "nextjs"
     schedule:
-      internal: "monthly"
+      interval: "monthly"
       timezone: UTC
       time: "07:00"
   - package-ecosystem: "npm"
     directory: "plain"
     schedule:
-      internal: "monthly"
+      interval: "monthly"
       timezone: UTC
       time: "07:00"
   - package-ecosystem: "npm"
     directory: "react-native"
     schedule:
-      internal: "monthly"
+      interval: "monthly"
       timezone: UTC
       time: "07:00"
   - package-ecosystem: "npm"
     directory: "react/cra"
     schedule:
-      internal: "monthly"
+      interval: "monthly"
       timezone: UTC
       time: "07:00"
   - package-ecosystem: "npm"
     directory: "react/esbuild"
     schedule:
-      internal: "monthly"
+      interval: "monthly"
       timezone: UTC
       time: "07:00"
   - package-ecosystem: "npm"
     directory: "react/parcel"
     schedule:
-      internal: "monthly"
+      interval: "monthly"
       timezone: UTC
       time: "07:00"
   - package-ecosystem: "npm"
     directory: "react/rollup"
     schedule:
-      internal: "monthly"
+      interval: "monthly"
       timezone: UTC
       time: "07:00"
   - package-ecosystem: "npm"
     directory: "react/vite"
     schedule:
-      internal: "monthly"
+      interval: "monthly"
       timezone: UTC
       time: "07:00"
   - package-ecosystem: "npm"
     directory: "react/webpack"
     schedule:
-      internal: "monthly"
+      interval: "monthly"
       timezone: UTC
       time: "07:00"
   - package-ecosystem: "npm"
     directory: "react/yarn3-unplugged"
     schedule:
-      internal: "monthly"
+      interval: "monthly"
       timezone: UTC
       time: "07:00"
   - package-ecosystem: "npm"
     directory: "react/yarn3"
     schedule:
-      internal: "monthly"
+      interval: "monthly"
       timezone: UTC
       time: "07:00"
   - package-ecosystem: "npm"
     directory: "remix"
     schedule:
-      internal: "monthly"
+      interval: "monthly"
       timezone: UTC
       time: "07:00"
   - package-ecosystem: "npm"
     directory: "svelte"
     schedule:
-      internal: "monthly"
+      interval: "monthly"
       timezone: UTC
       time: "07:00"
   - package-ecosystem: "npm"
     directory: "vue"
     schedule:
-      internal: "monthly"
+      interval: "monthly"
       timezone: UTC
       time: "07:00"
-


### PR DESCRIPTION
Dependabot doesn't inheretly find all nested package.json, and in this case it's complaining it can't find any [1]. It also doesn't support wildcards, so the hack scripts options to handle that are complex [2].

We could add some generate/lint rules to ensure the dependabot configuration is up to date, but that seems overkill for this repo.

1: https://github.com/bufbuild/connect-web-integration/network/updates/496698197
2: https://github.com/dependabot/dependabot-core/issues/2178#issuecomment-742259742