### PR TITLE
Fix Playwright in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,8 +16,6 @@ jobs:
         uses: pnpm/action-setup@v2
         with:
           version: 7
-      - name: Install Playwright
-        run: npx playwright install --with-deps
       - name: Setup Buf
         uses: bufbuild/buf-setup-action@v1.9.0
         with:

--- a/svelte/package-lock.json
+++ b/svelte/package-lock.json
@@ -12,7 +12,7 @@
                 "@bufbuild/protobuf": "^1.0.0",
                 "@bufbuild/protoc-gen-connect-web": "^0.5.0",
                 "@bufbuild/protoc-gen-es": "^1.0.0",
-                "@playwright/test": "^1.29.1",
+                "@playwright/test": "^1.30.0",
                 "@sveltejs/adapter-auto": "next",
                 "@sveltejs/kit": "next",
                 "@typescript-eslint/eslint-plugin": "^5.47.1",
@@ -252,13 +252,13 @@
             }
         },
         "node_modules/@playwright/test": {
-            "version": "1.29.1",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.29.1.tgz",
-            "integrity": "sha512-iQxk2DX5U9wOGV3+/Jh9OHPsw5H3mleUL2S4BgQuwtlAfK3PnKvn38m4Rg9zIViGHVW24opSm99HQm/UFLEy6w==",
+            "version": "1.30.0",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.30.0.tgz",
+            "integrity": "sha512-SVxkQw1xvn/Wk/EvBnqWIq6NLo1AppwbYOjNLmyU0R1RoQ3rLEBtmjTnElcnz8VEtn11fptj1ECxK0tgURhajw==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*",
-                "playwright-core": "1.29.1"
+                "playwright-core": "1.30.0"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -2422,9 +2422,9 @@
             }
         },
         "node_modules/playwright-core": {
-            "version": "1.29.1",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.29.1.tgz",
-            "integrity": "sha512-20Ai3d+lMkWpI9YZYlxk8gxatfgax5STW8GaMozAHwigLiyiKQrdkt7gaoT9UQR8FIVDg6qVXs9IoZUQrDjIIg==",
+            "version": "1.30.0",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.30.0.tgz",
+            "integrity": "sha512-7AnRmTCf+GVYhHbLJsGUtskWTE33SwMZkybJ0v6rqR1boxq2x36U7p1vDRV7HO2IwTZgmycracLxPEJI49wu4g==",
             "dev": true,
             "bin": {
                 "playwright": "cli.js"
@@ -3390,13 +3390,13 @@
             }
         },
         "@playwright/test": {
-            "version": "1.29.1",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.29.1.tgz",
-            "integrity": "sha512-iQxk2DX5U9wOGV3+/Jh9OHPsw5H3mleUL2S4BgQuwtlAfK3PnKvn38m4Rg9zIViGHVW24opSm99HQm/UFLEy6w==",
+            "version": "1.30.0",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.30.0.tgz",
+            "integrity": "sha512-SVxkQw1xvn/Wk/EvBnqWIq6NLo1AppwbYOjNLmyU0R1RoQ3rLEBtmjTnElcnz8VEtn11fptj1ECxK0tgURhajw==",
             "dev": true,
             "requires": {
                 "@types/node": "*",
-                "playwright-core": "1.29.1"
+                "playwright-core": "1.30.0"
             }
         },
         "@polka/url": {
@@ -4853,9 +4853,9 @@
             "dev": true
         },
         "playwright-core": {
-            "version": "1.29.1",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.29.1.tgz",
-            "integrity": "sha512-20Ai3d+lMkWpI9YZYlxk8gxatfgax5STW8GaMozAHwigLiyiKQrdkt7gaoT9UQR8FIVDg6qVXs9IoZUQrDjIIg==",
+            "version": "1.30.0",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.30.0.tgz",
+            "integrity": "sha512-7AnRmTCf+GVYhHbLJsGUtskWTE33SwMZkybJ0v6rqR1boxq2x36U7p1vDRV7HO2IwTZgmycracLxPEJI49wu4g==",
             "dev": true
         },
         "postcss": {

--- a/svelte/package.json
+++ b/svelte/package.json
@@ -4,7 +4,8 @@
     "scripts": {
         "start": "npm run buf:generate && vite dev --port 3000",
         "build": "vite build",
-        "test": "playwright test",
+        "test": "npm run playwright:install && playwright test",
+        "playwright:install": "playwright install",
         "buf:generate": "buf generate buf.build/bufbuild/eliza",
         "preview": "vite preview",
         "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",

--- a/svelte/package.json
+++ b/svelte/package.json
@@ -17,7 +17,7 @@
         "@bufbuild/protobuf": "^1.0.0",
         "@bufbuild/protoc-gen-connect-web": "^0.5.0",
         "@bufbuild/protoc-gen-es": "^1.0.0",
-        "@playwright/test": "^1.29.1",
+        "@playwright/test": "^1.30.0",
         "@sveltejs/adapter-auto": "next",
         "@sveltejs/kit": "next",
         "@typescript-eslint/eslint-plugin": "^5.47.1",


### PR DESCRIPTION
The Svelte project is the only project that uses Playwright.  However, we were installing the Playwright browsers at the top-level GH Action which made the browsers under use out of sync with what Svelte was testing.  So, the browser install was moved inside the Svelte project.